### PR TITLE
feat(stream): add conversationId to stream events metadata

### DIFF
--- a/src/dify-chat-language-model.ts
+++ b/src/dify-chat-language-model.ts
@@ -222,6 +222,17 @@ export class DifyChatLanguageModel implements LanguageModelV2 {
                     controller.enqueue({
                       type: "text-start",
                       id: "0",
+                      ...(conversationId || messageId || taskId
+                        ? {
+                            providerMetadata: {
+                              difyWorkflowData: {
+                                ...(conversationId ? { conversationId: conversationId as JSONValue } : {}),
+                                ...(messageId ? { messageId: messageId as JSONValue } : {}),
+                                ...(taskId ? { taskId: taskId as JSONValue } : {}),
+                              },
+                            },
+                          }
+                        : {}),
                     });
                   }
 
@@ -229,6 +240,17 @@ export class DifyChatLanguageModel implements LanguageModelV2 {
                     type: "text-delta",
                     id: "0",
                     delta: data.answer,
+                    ...(conversationId || messageId || taskId
+                      ? {
+                          providerMetadata: {
+                            difyWorkflowData: {
+                              ...(conversationId ? { conversationId: conversationId as JSONValue } : {}),
+                              ...(messageId ? { messageId: messageId as JSONValue } : {}),
+                              ...(taskId ? { taskId: taskId as JSONValue } : {}),
+                            },
+                          },
+                        }
+                      : {}),
                   });
 
                   // Type guard for id property


### PR DESCRIPTION
Include conversationId in providerMetadata for text-start, text-delta,  and finish events to enable session continuity tracking.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add conversationId to stream event metadata to support session continuity and easier event correlation. Also includes messageId and taskId when available.

- New Features
  - Attach providerMetadata.difyWorkflowData with conversationId/messageId/taskId to text-start, text-delta, and finish events.

<sup>Written for commit 368c5ed9276ab13a02cbcacd6e652a677166726f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

